### PR TITLE
AB#374 - Fixed mix case n/A causing service unavailable for subsidy awards

### DIFF
--- a/src/main/java/com/beis/subsidy/control/accessmanagementservice/utils/SearchUtils.java
+++ b/src/main/java/com/beis/subsidy/control/accessmanagementservice/utils/SearchUtils.java
@@ -77,10 +77,10 @@ public class SearchUtils {
 	 */
 	public static String formatedFullAmountRange(String amountRange) {
 		String finalAmtRange = "NA";
+		amountRange = amountRange.toUpperCase();
 		if (StringUtils.isNotBlank(amountRange) &&
 				!(amountRange.equalsIgnoreCase("NA") || amountRange.contains("N/A")
-						|| amountRange.contains("n/a"))
-				&& !amountRange.endsWith(">")) {
+				&& !amountRange.endsWith(">"))) {
 
 			StringBuilder format = new StringBuilder();
 			String[] tokens = amountRange.split("-");


### PR DESCRIPTION
Added amountRange.toUpperCase accessmanagementservice.utils.SearchUtils#formatedFullAmountRange so awards with N/A range values with mixed case e.g. 'n/A' do not cause a service unavailable error when viewed