### PR TITLE
fix: Added SC number to subsidy awardsearch queries for GA

### DIFF
--- a/src/main/java/com/beis/subsidy/control/accessmanagementservice/service/impl/AccessManagementServiceImpl.java
+++ b/src/main/java/com/beis/subsidy/control/accessmanagementservice/service/impl/AccessManagementServiceImpl.java
@@ -466,7 +466,9 @@ public class AccessManagementServiceImpl implements AccessManagementService {
                                 .or(SearchUtils.checkNullOrEmptyString(searchName)
                                         ? null :AwardSpecificationUtils.grantingAuthorityName(searchName.trim()))
                                 .or(SearchUtils.checkNullOrEmptyString(searchName)
-                                        ? null :AwardSpecificationUtils.beneficiaryName(searchName.trim())))
+                                        ? null :AwardSpecificationUtils.beneficiaryName(searchName.trim()))
+                                .or(SearchUtils.checkNullOrEmptyString(searchName)
+                                        ? null :AwardSpecificationUtils.subsidyNumberLike(searchName.toUpperCase().trim())))
                 .and(SearchUtils.checkNullOrEmptyString(gaName) ? null :
                         AwardSpecificationUtils.grantingAuthorityName(gaName.trim()))
                 .and(SearchUtils.checkNullOrEmptyString(status)


### PR DESCRIPTION
Added a missing conditional to subsidy award search for GA accounts that allows SC numbers to be used as a search query